### PR TITLE
Store containers/components in a single file

### DIFF
--- a/BEST_PRACTICES.md
+++ b/BEST_PRACTICES.md
@@ -9,6 +9,7 @@
     - separate presentational and container components
         - [comparison] (http://redux.js.org/docs/basics/UsageWithReact.html#presentational-and-container-components)
         - [explanation of container components] (https://medium.com/@learnreact/container-components-c0e67432e005)
+        - store each cotainer/component pair in a single file, in the components directory
     - use prop types
     - presentational components
         - write functional stateless components unless there is a need to use local state or the lifecycle methods


### PR DESCRIPTION
I'm not entirely sure how I feel about this yet, so opening this for
discussion. The idea is that containers and components are tightly
coupled, so splitting them across two files introduces unnecessary
indirection, making questions like 'where did this prop come from?'
harder to answer.

A snippet from a conversation on Slack:

    > I tend to see those pulled out into a "container"
    > buuuut, why?
    > I'm unpacking `actions` there
    > so if I wanted to know where the hell `performGuestAuthentication` was coming from, how would I know?
    > I can't grep for that string, because it doesn't exist at the point where it's passed into the component
    > so I'd have to use my implicit knowledge where I just happen to know that this thing is wrapped in a component, _or_ try to figure out the screen where this thing is used and trace my way down the stack
    > both of those options suck

Overall conversation starts roughly at:
https://thoughtbot.slack.com/archives/C02HVTS7H/p1504645339000304

The only downside to storing them in the same place I can think of is
file size, but part me thinks that if that becomes a problem it's an
indication that the container/component is doing too much. Are there any
other downsides to this approach? Are there any wins to splitting them
into two files?

Additionally, the app referenced in the Slack convo exported only one
object from the file, which was the container. E.g.

```js
// components/my-component.js
const MyComponent = () => (<div>...</div>);

const container = connect(..., ...)(component);

export { container as MyComponent };
```

This could be a little problematic for testing, since it's possible (likely?) we'll want access to the presentation component. I think it'd be fine to export that as well. Maybe export the container as the default, and the presentation component alongside it as a named export?